### PR TITLE
Test for fixing playercount being broken after map change

### DIFF
--- a/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
+++ b/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
@@ -29,10 +29,10 @@ function PlayerLeft(event)
     end
 end
 
-function RoundStart(event)
+--[[function RoundStart(event)
     for _  in pairs(players) do playerCount = playerCount + 1 end
-    --print("New Round. Checking Player Count: " .. playerCount)
-end
+    print("New Round. Checking Player Count: " .. playerCount)
+end]]--
 
 function DEBUG_PlayerCheck(event)
     print("DEBUG: Current Player Count: " .. playerCount)
@@ -41,7 +41,7 @@ end
 function Activate()
     ListenToGameEvent("player_connect_full", PlayerJoined, nil)
     ListenToGameEvent("player_disconnect", PlayerLeft, nil)
-    ListenToGameEvent("round_start", RoundStart, nil)
+    --ListenToGameEvent("round_start", RoundStart, nil)
     Convars:RegisterCommand("DEBUG_PrintPlayerCount", DEBUG_PlayerCheck, "Writes all cvars into a the statusConvar.cfg", 0x1000)
 end
 

--- a/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
+++ b/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
@@ -22,24 +22,9 @@ function playerLeft(event)
     --print("Player left, Player Count: " .. playerLimit)
 end
 
-function newMapFix(event)
-    if(ScriptGetRoundsPlayed() == 0) then
-        if(ScriptIsWarmupPeriod() == false) then
-            print("Player spawned in first round, Player Count: " .. playerLimit)
-            playerLimit = playerlimit + 1
-        elseif (ScriptIsWarmupPeriod() == true) then
-            print("New map started. Not counting players yet")
-            playerLimit = 0
-        end
-    else
-        print("We are on round: " .. ScriptGetRoundsPlayed())
-    end
-end
-
 function Activate()
     ListenToGameEvent("player_connect", playerJoined, nil)
     ListenToGameEvent("player_disconnect", playerLeft, nil)
-    ListenToGameEvent("player_spawn", newMapFix, nil)
 end
 
 Activate()

--- a/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
+++ b/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
@@ -22,9 +22,24 @@ function playerLeft(event)
     --print("Player left, Player Count: " .. playerLimit)
 end
 
+function newMapFix(event)
+    if(ScriptGetRoundsPlayed() == 0) then
+        if(ScriptIsWarmupPeriod() == false) then
+            print("Player spawned in first round, Player Count: " .. playerLimit)
+            playerLimit = playerlimit + 1
+        elseif (ScriptIsWarmupPeriod() == true) then
+            print("New map started. Not counting players yet")
+            playerLimit = 0
+        end
+    else
+        print("We are on round: " .. ScriptGetRoundsPlayed())
+    end
+end
+
 function Activate()
     ListenToGameEvent("player_connect", playerJoined, nil)
     ListenToGameEvent("player_disconnect", playerLeft, nil)
+    ListenToGameEvent("player_spawn", newMapFix, nil)
 end
 
 Activate()

--- a/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
+++ b/VPK/pak02/scripts/vscripts/patches/maxplayerCheck.lua
@@ -1,30 +1,48 @@
-local playerLimit = 0
+local playerCount = 0
+local players = Entities:FindAllByClassname("player")
+local playerLimit = 12
 
-function playerJoined(event)
-    playerLimit = playerLimit + 1
-    --for k,v in pairs(event) do
-        --print( k,v )
-    --end
-    if playerLimit > 14 then
-        --print("Too many players to join server. Kicking joining player...")
+function PlayerJoined(event)
+    --[[for k,v in pairs(event) do
+        print( k,v )
+    end]]--
+    playerCount = playerCount + 1
+    if playerCount > playerLimit then
+        print("Too many players to join server. Kicking joining player...")
         SendToServerConsole("kickid " .. event.userid .. " Server is full!")
-    elseif playerLimit == 14 then
-        --print("Player joined, Player Count: " .. playerLimit)
-    elseif playerLimit < 14 then
-        --print("Player joined, Player Count: " .. playerLimit)
+    elseif playerCount == playerLimit then
+        print("Player joined, Player Count: " .. playerCount)
+    elseif playerCount < playerLimit then
+        print("Player joined, Player Count: " .. playerCount)
     else
         print("Player number is higher then max player. DEBUG THIS!")
     end
 end
 
-function playerLeft(event)
-    playerLimit = playerLimit - 1
-    --print("Player left, Player Count: " .. playerLimit)
+function PlayerLeft(event)
+    if event.networkid == "BOT" then
+        --print("Player was a bot, don't counter player couter...")
+    else
+        --print("Player was not a bot, counting down...")
+        playerCount = playerCount - 1
+        print("Player left, Player Count: " .. playerCount)
+    end
+end
+
+function RoundStart(event)
+    for _  in pairs(players) do playerCount = playerCount + 1 end
+    --print("New Round. Checking Player Count: " .. playerCount)
+end
+
+function DEBUG_PlayerCheck(event)
+    print("DEBUG: Current Player Count: " .. playerCount)
 end
 
 function Activate()
-    ListenToGameEvent("player_connect", playerJoined, nil)
-    ListenToGameEvent("player_disconnect", playerLeft, nil)
+    ListenToGameEvent("player_connect_full", PlayerJoined, nil)
+    ListenToGameEvent("player_disconnect", PlayerLeft, nil)
+    ListenToGameEvent("round_start", RoundStart, nil)
+    Convars:RegisterCommand("DEBUG_PrintPlayerCount", DEBUG_PlayerCheck, "Writes all cvars into a the statusConvar.cfg", 0x1000)
 end
 
 Activate()


### PR DESCRIPTION
The counter for players is getting reset when the map resets and due to **player_connect** not getting triggered due to the players already being on the server when the map switches. The player count gets miscalculated